### PR TITLE
Update SendcloudGateway.php

### DIFF
--- a/src/Gateways/SendcloudGateway.php
+++ b/src/Gateways/SendcloudGateway.php
@@ -44,8 +44,8 @@ class SendcloudGateway extends Gateway
         $params = [
             'smsUser' => $config->get('sms_user'),
             'templateId' => $message->getTemplate($this),
-            'msgType' => $to->getIDDCode() ? 2 : 0,
-            'phone' => $to->getZeroPrefixedNumber(),
+            'msgType' => $to->getIDDCode() != 86 ? 2 : 0,
+            'phone' => $to->getIDDCode() != 86 ? $to->getZeroPrefixedNumber() : $to->getNumber(),
             'vars' => $this->formatTemplateVars($message->getData($this)),
         ];
 


### PR DESCRIPTION
修复两个问题
1、模板类型不匹配，返回434；不管国内、国外都传入国家区号，会导致接口请求返回这个错误，主要是因为这里根据国家区号判断模板类型
2、手机号格式错误，返回412；国内的应该传18888888888格式，国外的应该传008618888888888格式